### PR TITLE
Update to gleam_stdlib v0.60.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -3,10 +3,10 @@
 
 packages = [
   { name = "gleam_deque", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_deque", source = "hex", outer_checksum = "64D77068931338CF0D0CB5D37522C3E3CCA7CB7D6C5BACB41648B519CC0133C7" },
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
   { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
-  { name = "gleam_stdlib", version = "0.53.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "53F3E1E56F692C20FA3E0A23650AC46592464E40D8EF3EC7F364FB328E73CDF5" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
   { name = "lifeguard", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_deque", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "lifeguard", source = "hex", outer_checksum = "043A44839FC9CCD209DE305F0EC96C09AB8F6A830D7346A49829321B148EE730" },
   { name = "mug", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "mug", source = "hex", outer_checksum = "C5F62A3FD753B823CE296ED1B223D4B2FF06E91170A7DE35A283D70BB74B700E" },
 ]

--- a/src/radish.gleam
+++ b/src/radish.gleam
@@ -43,39 +43,33 @@ pub type ExpireCondition {
 }
 
 pub fn start(host: String, port: Int, options: List(StartOption)) {
-  let #(timeout, options) = case
-    list.pop_map(options, fn(item) {
+  let timeout =
+    list.find_map(options, fn(item) {
       case item {
         Timeout(timeout) -> Ok(timeout)
         _ -> Error(Nil)
       }
     })
-  {
-    Ok(result) -> result
-    Error(Nil) -> #(1024, options)
-  }
+    |> result.unwrap(1024)
 
-  let #(pool_size, options) = case
-    list.pop_map(options, fn(item) {
+  let pool_size =
+    list.find_map(options, fn(item) {
       case item {
         PoolSize(pool_size) -> Ok(pool_size)
         _ -> Error(Nil)
       }
     })
-  {
-    Ok(result) -> result
-    Error(Nil) -> #(3, options)
-  }
+    |> result.unwrap(3)
 
   use client <- result.then(client.start(host, port, timeout, pool_size))
 
   let options =
-    list.map(options, fn(item) {
+    list.filter_map(options, fn(item) {
       case item {
-        Auth(password) -> command.Auth(password)
+        Auth(password) -> Ok(command.Auth(password))
         AuthWithUsername(username, password) ->
-          command.AuthWithUsername(username, password)
-        Timeout(_) | PoolSize(_) -> command.AuthWithUsername("", "")
+          Ok(command.AuthWithUsername(username, password))
+        Timeout(_) | PoolSize(_) -> Error(Nil)
       }
     })
 

--- a/src/radish/client.gleam
+++ b/src/radish/client.gleam
@@ -8,7 +8,7 @@ import radish/resp.{type Value}
 import radish/tcp
 
 import lifeguard
-import mug.{type Error}
+import mug
 
 pub type Message {
   Command(BitArray, process.Subject(Result(List(Value), error.Error)), Int)


### PR DESCRIPTION
Remove the use of `list.pop_map` and replace it with (IMO) a cleaner approach to options parsing.

Fixes #9.
Replaces #10.